### PR TITLE
Replace the usage of typeid with boost::typeindex in order to allow c…

### DIFF
--- a/include/boost/property_tree/detail/ptree_implementation.hpp
+++ b/include/boost/property_tree/detail/ptree_implementation.hpp
@@ -15,6 +15,7 @@
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/assert.hpp>
 #include <boost/utility/swap.hpp>
+#include <boost/type_index.hpp>
 #include <memory>
 
 #if (defined(BOOST_MSVC) && \
@@ -669,7 +670,8 @@ namespace boost { namespace property_tree
         }
         BOOST_PROPERTY_TREE_THROW(ptree_bad_data(
             std::string("conversion of data to type \"") +
-            typeid(Type).name() + "\" failed", data()));
+            boost::typeindex::type_id<Type>().pretty_name() + 
+            "\" failed", data()));
     }
 
     template<class K, class D, class C>
@@ -824,7 +826,8 @@ namespace boost { namespace property_tree
             data() = *o;
         } else {
             BOOST_PROPERTY_TREE_THROW(ptree_bad_data(
-                std::string("conversion of type \"") + typeid(Type).name() +
+                std::string("conversion of type \"") + 
+                boost::typeindex::type_id<Type>().pretty_name() +
                 "\" to data failed", boost::any()));
         }
     }


### PR DESCRIPTION
…ompiling without rtti support.